### PR TITLE
Fixing missing forward slash in file path

### DIFF
--- a/db_chart.py
+++ b/db_chart.py
@@ -35,7 +35,7 @@ target = DB_PATH
 
 if not os.path.exists(DB_PATH):
     print("No backup database (crypto_trading.db.backup) found, creating one...")
-    f = open(BOT_PATH + "data/crypto_trading.db.backup",'w')
+    f = open(BOT_PATH + "/data/crypto_trading.db.backup",'w')
 
 shutil.copyfile(original, target)
 


### PR DESCRIPTION
Missing forward slash in file path when attempting to create `crypto_trading.db.backup` was causing an error when set up via 
[install script](https://github.com/Enriko82/BTB-Install-script).

Produced the following error in the logs:
```
Sep  3 23:21:15 binance-trade-bot python3[3230]: Traceback (most recent call last):
Sep  3 23:21:15 binance-trade-bot python3[3230]:   File "../binance-chart-plugin-telegram-bot/db_chart.py", line 38, in <module>
Sep  3 23:21:15 binance-trade-bot python3[3230]:     f = open(BOT_PATH + "data/crypto_trading.db.backup",'w')
Sep  3 23:21:15 binance-trade-bot python3[3230]: FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/binance-trade-bot/btb-paper-trade/binance-trade-botdata/crypto_trading.db.backup'
```