### PR TITLE
Fix growth % calculation

### DIFF
--- a/db_chart.py
+++ b/db_chart.py
@@ -115,7 +115,7 @@ for crypto in range(0,len(exchange_crypto)):
     for order in orders.fetchall():
         order_list.append(order[0])
     
-    perc = round(((order_list[-1] - order_list[0])/order[0])*100, 3) if len(order_list) > 0 else 0.0
+    perc = round(((order_list[-1] - order_list[0])/order_list[0])*100, 3) if len(order_list) > 0 else 0.0
     perc_str = "+"+str(perc) if perc > 0 else str(perc)
     
     coin_grow.append(order_list)


### PR DESCRIPTION
Base calculation does not work.

This solves the issue:
Ex for 2 coins:
ORN: +29.014% >> went from 110.1 -> 155.1 > should be 40.8719% on 21 trades
QNT: +51.619% >> went from 2.48 -> 5.126 > should be 106.694% on 32 trades

After patch:
ORN: +40.872%
QNT: +106.694%